### PR TITLE
Fix broken video embeds on Albert Park project page

### DIFF
--- a/projects/albert-park.html
+++ b/projects/albert-park.html
@@ -46,10 +46,24 @@
         <p>Albert Park proves how bold restraint transforms a home. DSBuilt turned a dark waterfront apartment into a light-filled retreat with refined joinery, brass accents and clever custom details, creating a space that feels luxurious, effortless and unmistakably tailored to the way our clients live.</p>
       </div>
       <div class="video-embed">
-        <iframe src="https://www.youtube.com/embed/7JnwGgOOGeM" allowfullscreen title="YouTube Video"></iframe>
+        <iframe
+          src="https://www.youtube-nocookie.com/embed/7JnwGgOOGeM?rel=0"
+          title="Albert Park walkthrough video"
+          loading="lazy"
+          referrerpolicy="strict-origin-when-cross-origin"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen
+        ></iframe>
       </div>
       <div class="video-embed">
-        <iframe src="https://www.youtube.com/embed/vcpHGMMsrVk" allowfullscreen title="YouTube Video"></iframe>
+        <iframe
+          src="https://www.youtube-nocookie.com/embed/vcpHGMMsrVk?rel=0"
+          title="Albert Park renovation detail video"
+          loading="lazy"
+          referrerpolicy="strict-origin-when-cross-origin"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen
+        ></iframe>
       </div>
       <div class="projectSingle-gallery">
         <img src="../images/projects/albert_park/gallery-1.jpg" alt="Albert Park - Image 1" />


### PR DESCRIPTION
### Motivation
- The Albert Park project page contained YouTube iframe embeds that were failing to render reliably and needed privacy and compatibility improvements. 
- Switching to privacy-enhanced embed URLs and adding modern iframe attributes improves playback in restrictive contexts and reduces third-party tracking. 

### Description
- Replaced both `https://www.youtube.com/embed/...` iframes with `https://www.youtube-nocookie.com/embed/...?rel=0` on `projects/albert-park.html`. 
- Added explicit `title`, `loading="lazy"`, `referrerpolicy="strict-origin-when-cross-origin"`, and a full `allow` permission list to each iframe for better compatibility and UX. 
- Updated the file and committed the change with the message `Fix Albert Park video embed iframes`. 

### Testing
- Reviewed the HTML changes with `git diff -- projects/albert-park.html` to confirm both embeds were updated as intended. 
- Printed the updated section with `nl -ba projects/albert-park.html | sed -n '42,90p'` to verify the new iframe attributes are present. 
- Committed the change successfully using `git commit -m "Fix Albert Park video embed iframes"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8a86cd9888328bb92bdef9831b210)