### PR TITLE
Reorder projects and update homepage hero slider to priority sequence

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,8 +44,18 @@
   <!-- Hero Slider -->
   <section class="heroSlider" id="heroSlider">
     <div class="heroSlider-slide is-active">
-      <a href="/projects/albert-park.html" class="heroSlider-slide-link">
-        <img src="images/projects/albert_park/cover.jpg" class="heroSlider-slide-image" alt="Albert Park" />
+      <a href="/projects/port-melbourne.html" class="heroSlider-slide-link">
+        <img src="images/projects/port-melbourne/cover.jpg" class="heroSlider-slide-image" alt="Port Melbourne" />
+      </a>
+    </div>
+    <div class="heroSlider-slide">
+      <a href="/projects/blairgowrie.html" class="heroSlider-slide-link">
+        <img src="images/projects/blairgowrie/cover.jpg" class="heroSlider-slide-image" alt="Blairgowrie" />
+      </a>
+    </div>
+    <div class="heroSlider-slide">
+      <a href="/projects/highett.html" class="heroSlider-slide-link">
+        <img src="images/projects/highett/cover.jpg" class="heroSlider-slide-image" alt="Highett" />
       </a>
     </div>
     <div class="heroSlider-slide">
@@ -54,26 +64,22 @@
       </a>
     </div>
     <div class="heroSlider-slide">
+      <a href="/projects/ashburton.html" class="heroSlider-slide-link">
+        <img src="images/projects/ashburton/cover.jpg" class="heroSlider-slide-image" alt="Ashburton" />
+      </a>
+    </div>
+    <div class="heroSlider-slide">
       <a href="/projects/brighton-east.html" class="heroSlider-slide-link">
         <img src="images/projects/brighton_east/cover.jpg" class="heroSlider-slide-image" alt="Brighton East" />
       </a>
     </div>
-    <div class="heroSlider-slide">
-      <a href="/projects/narre-warren-south.html" class="heroSlider-slide-link">
-        <img src="images/projects/narre_warren_south/cover.jpg" class="heroSlider-slide-image" alt="Narre Warren South" />
-      </a>
-    </div>
-    <div class="heroSlider-slide">
-      <a href="/projects/vermont.html" class="heroSlider-slide-link">
-        <img src="images/projects/vermont/cover.jpg" class="heroSlider-slide-image" alt="Vermont" />
-      </a>
-    </div>
     <nav class="slidePager" id="slidePager">
-      <button class="slidePager-item is-selected" data-slide="0">Albert Park</button>
-      <button class="slidePager-item" data-slide="1">Cheltenham</button>
-      <button class="slidePager-item" data-slide="2">Brighton East</button>
-      <button class="slidePager-item" data-slide="3">Narre Warren South</button>
-      <button class="slidePager-item" data-slide="4">Vermont</button>
+      <button class="slidePager-item is-selected" data-slide="0">Port Melbourne</button>
+      <button class="slidePager-item" data-slide="1">Blairgowrie</button>
+      <button class="slidePager-item" data-slide="2">Highett</button>
+      <button class="slidePager-item" data-slide="3">Cheltenham</button>
+      <button class="slidePager-item" data-slide="4">Ashburton</button>
+      <button class="slidePager-item" data-slide="5">Brighton East</button>
     </nav>
   </section>
 
@@ -83,13 +89,46 @@
       <h2 class="section-title">OUR PROJECTS</h2>
       <div class="previewGrid" id="previewGrid">
         <div class="previewGrid-item previewGrid-item--feature" data-category="renovation">
-          <a href="/projects/albert-park.html" class="previewGrid-link">
+          <a href="/projects/port-melbourne.html" class="previewGrid-link">
             <div class="previewGrid-image">
-              <img src="images/projects/albert_park/cover.jpg" alt="Albert Park" />
+              <img src="images/projects/port-melbourne/cover.jpg" alt="Port Melbourne" />
             </div>
             <div class="previewGrid-content">
               <span class="previewGrid-category">Renovation</span>
-              <h3 class="previewGrid-title">Albert Park</h3>
+              <h3 class="previewGrid-title">Port Melbourne</h3>
+            </div>
+          </a>
+        </div>
+        <div class="previewGrid-item" data-category="new-build">
+          <a href="/projects/blairgowrie.html" class="previewGrid-link">
+            <div class="previewGrid-image">
+              <img src="images/projects/blairgowrie/cover.jpg" alt="Blairgowrie" />
+            </div>
+            <div class="previewGrid-content">
+              <span class="previewGrid-category">New Build</span>
+              <h3 class="previewGrid-title">Blairgowrie</h3>
+            </div>
+          </a>
+        </div>
+        <div class="previewGrid-item" data-category="duplex">
+          <a href="/projects/highett.html" class="previewGrid-link">
+            <div class="previewGrid-image">
+              <img src="images/projects/highett/cover.jpg" alt="Highett" />
+            </div>
+            <div class="previewGrid-content">
+              <span class="previewGrid-category">Duplex</span>
+              <h3 class="previewGrid-title">Highett</h3>
+            </div>
+          </a>
+        </div>
+        <div class="previewGrid-item" data-category="new-build">
+          <a href="/projects/cheltenham.html" class="previewGrid-link">
+            <div class="previewGrid-image">
+              <img src="images/projects/cheltenham/cover.jpg" alt="Cheltenham" />
+            </div>
+            <div class="previewGrid-content">
+              <span class="previewGrid-category">New Build</span>
+              <h3 class="previewGrid-title">Cheltenham</h3>
             </div>
           </a>
         </div>
@@ -105,17 +144,6 @@
           </a>
         </div>
         <div class="previewGrid-item" data-category="new-build">
-          <a href="/projects/cheltenham.html" class="previewGrid-link">
-            <div class="previewGrid-image">
-              <img src="images/projects/cheltenham/cover.jpg" alt="Cheltenham" />
-            </div>
-            <div class="previewGrid-content">
-              <span class="previewGrid-category">New Build</span>
-              <h3 class="previewGrid-title">Cheltenham</h3>
-            </div>
-          </a>
-        </div>
-        <div class="previewGrid-item" data-category="new-build">
           <a href="/projects/brighton-east.html" class="previewGrid-link">
             <div class="previewGrid-image">
               <img src="images/projects/brighton_east/cover.jpg" alt="Brighton East" />
@@ -123,17 +151,6 @@
             <div class="previewGrid-content">
               <span class="previewGrid-category">New Build</span>
               <h3 class="previewGrid-title">Brighton East</h3>
-            </div>
-          </a>
-        </div>
-        <div class="previewGrid-item" data-category="new-build">
-          <a href="/projects/blairgowrie.html" class="previewGrid-link">
-            <div class="previewGrid-image">
-              <img src="images/projects/blairgowrie/cover.jpg" alt="Blairgowrie" />
-            </div>
-            <div class="previewGrid-content">
-              <span class="previewGrid-category">New Build</span>
-              <h3 class="previewGrid-title">Blairgowrie</h3>
             </div>
           </a>
         </div>

--- a/projects.html
+++ b/projects.html
@@ -58,13 +58,46 @@
   <section class="container">
     <div class="previewGrid" id="previewGrid">
       <div class="previewGrid-item previewGrid-item--feature" data-category="renovation">
-        <a href="/projects/albert-park.html" class="previewGrid-link">
+        <a href="/projects/port-melbourne.html" class="previewGrid-link">
           <div class="previewGrid-image">
-            <img src="images/projects/albert_park/cover.jpg" alt="Albert Park" />
+            <img src="images/projects/port-melbourne/cover.jpg" alt="Port Melbourne" />
           </div>
           <div class="previewGrid-content">
             <span class="previewGrid-category">Renovation</span>
-            <h3 class="previewGrid-title">Albert Park</h3>
+            <h3 class="previewGrid-title">Port Melbourne</h3>
+          </div>
+        </a>
+      </div>
+      <div class="previewGrid-item" data-category="new-build">
+        <a href="/projects/blairgowrie.html" class="previewGrid-link">
+          <div class="previewGrid-image">
+            <img src="images/projects/blairgowrie/cover.jpg" alt="Blairgowrie" />
+          </div>
+          <div class="previewGrid-content">
+            <span class="previewGrid-category">New Build</span>
+            <h3 class="previewGrid-title">Blairgowrie</h3>
+          </div>
+        </a>
+      </div>
+      <div class="previewGrid-item" data-category="duplex">
+        <a href="/projects/highett.html" class="previewGrid-link">
+          <div class="previewGrid-image">
+            <img src="images/projects/highett/cover.jpg" alt="Highett" />
+          </div>
+          <div class="previewGrid-content">
+            <span class="previewGrid-category">Duplex</span>
+            <h3 class="previewGrid-title">Highett</h3>
+          </div>
+        </a>
+      </div>
+      <div class="previewGrid-item" data-category="new-build">
+        <a href="/projects/cheltenham.html" class="previewGrid-link">
+          <div class="previewGrid-image">
+            <img src="images/projects/cheltenham/cover.jpg" alt="Cheltenham" />
+          </div>
+          <div class="previewGrid-content">
+            <span class="previewGrid-category">New Build</span>
+            <h3 class="previewGrid-title">Cheltenham</h3>
           </div>
         </a>
       </div>
@@ -80,17 +113,6 @@
         </a>
       </div>
       <div class="previewGrid-item" data-category="new-build">
-        <a href="/projects/cheltenham.html" class="previewGrid-link">
-          <div class="previewGrid-image">
-            <img src="images/projects/cheltenham/cover.jpg" alt="Cheltenham" />
-          </div>
-          <div class="previewGrid-content">
-            <span class="previewGrid-category">New Build</span>
-            <h3 class="previewGrid-title">Cheltenham</h3>
-          </div>
-        </a>
-      </div>
-      <div class="previewGrid-item" data-category="new-build">
         <a href="/projects/brighton-east.html" class="previewGrid-link">
           <div class="previewGrid-image">
             <img src="images/projects/brighton_east/cover.jpg" alt="Brighton East" />
@@ -101,14 +123,14 @@
           </div>
         </a>
       </div>
-      <div class="previewGrid-item" data-category="new-build">
-        <a href="/projects/blairgowrie.html" class="previewGrid-link">
+      <div class="previewGrid-item" data-category="renovation">
+        <a href="/projects/albert-park.html" class="previewGrid-link">
           <div class="previewGrid-image">
-            <img src="images/projects/blairgowrie/cover.jpg" alt="Blairgowrie" />
+            <img src="images/projects/albert_park/cover.jpg" alt="Albert Park" />
           </div>
           <div class="previewGrid-content">
-            <span class="previewGrid-category">New Build</span>
-            <h3 class="previewGrid-title">Blairgowrie</h3>
+            <span class="previewGrid-category">Renovation</span>
+            <h3 class="previewGrid-title">Albert Park</h3>
           </div>
         </a>
       </div>
@@ -134,17 +156,6 @@
           </div>
         </a>
       </div>
-      <div class="previewGrid-item" data-category="duplex">
-        <a href="/projects/highett.html" class="previewGrid-link">
-          <div class="previewGrid-image">
-            <img src="images/projects/highett/cover.jpg" alt="Highett" />
-          </div>
-          <div class="previewGrid-content">
-            <span class="previewGrid-category">Duplex</span>
-            <h3 class="previewGrid-title">Highett</h3>
-          </div>
-        </a>
-      </div>
       <div class="previewGrid-item" data-category="renovation">
         <a href="/projects/narre-warren-south.html" class="previewGrid-link">
           <div class="previewGrid-image">
@@ -164,17 +175,6 @@
           <div class="previewGrid-content">
             <span class="previewGrid-category">Renovation</span>
             <h3 class="previewGrid-title">Malvern East</h3>
-          </div>
-        </a>
-      </div>
-      <div class="previewGrid-item" data-category="renovation">
-        <a href="/projects/port-melbourne.html" class="previewGrid-link">
-          <div class="previewGrid-image">
-            <img src="images/projects/port-melbourne/cover.jpg" alt="Port Melbourne" />
-          </div>
-          <div class="previewGrid-content">
-            <span class="previewGrid-category">Renovation</span>
-            <h3 class="previewGrid-title">Port Melbourne</h3>
           </div>
         </a>
       </div>


### PR DESCRIPTION
### Motivation
- Surface six priority projects prominently by placing them first in the projects listings and ensuring the homepage hero slider shows the same six in the requested order: Port Melbourne, Blairgowrie, Highett, Cheltenham, Ashburton, Brighton East.

### Description
- Updated the homepage hero slider in `index.html` to show the six priority projects (and updated the slide pager labels and `data-slide` indices to match). 
- Reordered the featured project preview grid on the homepage (`index.html`) so the same six projects appear first in the requested sequence. 
- Reordered the main project grid in `projects.html` to place the six priority projects first and moved the remaining project cards after them. 
- Adjusted project card links, cover image paths and `data-category` values where needed to reflect the new ordering.

### Testing
- Verified the new ordering with a small regex-based Python check that extracts `<h3 class="previewGrid-title">` values from `index.html` and `projects.html`, which returned the requested sequence for the first six items in both files. 
- Verified the hero slider pager labels with a regex that extracted `slidePager-item` button labels and confirmed they match the new six-slide order. 
- Reviewed the `git diff` output to confirm only the intended HTML changes were made. 
- Attempted a `BeautifulSoup` parsing check, but `bs4` was not available in the environment so a regex fallback was used and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b83031688328b5490ee405c275d2)